### PR TITLE
Refactor dropdowns and add model dropdown to combination page

### DIFF
--- a/components/combination_intro.py
+++ b/components/combination_intro.py
@@ -1,6 +1,8 @@
 import dash_html_components as html
 import dash_core_components as dcc
 
+from components.navigation.dropdowns import model_links_from_combo
+
 
 def layout(combination):
 
@@ -28,10 +30,12 @@ def layout(combination):
                 ])
             ]),
             html.Div(className="row", children=[
-                html.Div(className="col-12", children=[
-                    html.Div(className="bg-white p-2 my-2 border border-warning ", children=[
+                html.Div(className="col-6", children=[
+                    html.Div(className="bg-white pt-3 px-4 pb-2 mb-3 border border-warning ", children=[
+                        html.H3("Drug information"),
+                        html.Hr(),
                         html.Div(className="row pb-4", children=[
-                            html.Div(className="col-3", children=[
+                            html.Div(className="col-6", children=[
                                 # html.H2(f"{drug1.drug_name}"),
                                 html.Table(children=[
                                     html.Tr(children=[
@@ -60,7 +64,7 @@ def layout(combination):
                                     ])
                                 ], className="table-borderless")
                             ]),
-                            html.Div(className="col-3", children=[
+                            html.Div(className="col-6", children=[
                                 # html.H2(drug2.drug_name),
                                 html.Table(children=[
                                     html.Tr([
@@ -91,6 +95,19 @@ def layout(combination):
                             ]),
                         ])
                     ])
+                ]),
+                html.Div(className="col-6", children=[
+                    html.Div(
+                        className="bg-white pt-3 px-4 pb-2 mb-3 border border-warning ",
+                        children=[
+                            html.H3("View combination in cell line"),
+                            html.Hr(),
+                            html.Div(className="row pb-4", children=[
+                                html.Div(className="col-12", children=[
+                                    model_links_from_combo(combination)
+                                ])
+                            ])
+                        ])
                 ])
             ])
         ]

--- a/components/matrix_intro.py
+++ b/components/matrix_intro.py
@@ -6,8 +6,9 @@ import dash_core_components as dcc
 import requests
 
 from app import app
-from components.matrix_navigation import replicate_links, links_to_other_models, \
-    links_to_other_combos
+from components.matrix_navigation import replicate_links_from_matrix
+from components.navigation.dropdowns import model_links_from_matrix, \
+    combo_links_from_matrix
 from components.single_agent.info import infoblock
 
 
@@ -142,25 +143,12 @@ def layout(matrix):
                          children=[
                              html.H3("Quick Navigation"),
                              html.Hr(),
-                             replicate_links(matrix),
-                             links_to_other_models(matrix),
-                             links_to_other_combos(matrix)
+                             replicate_links_from_matrix(matrix),
+                             model_links_from_matrix(matrix),
+                             combo_links_from_matrix(matrix)
                          ])
             ])
         ]),
         html.Div(id='hidden-div', className='d-none')
     ]
     )
-
-
-
-
-@app.callback(dash.dependencies.Output('matrix-url', 'pathname'),
-              [dash.dependencies.Input('dropdown-models', 'value'),
-               dash.dependencies.Input('dropdown-combos', 'value')])
-def dropdown_handler(dropdown_models_value, dropdown_combos_value):
-
-    value = dropdown_models_value or dropdown_combos_value
-    barcode, cmatrix = value.split('__')
-    return f"/matrix/{barcode}/{cmatrix}"
-

--- a/components/matrix_navigation.py
+++ b/components/matrix_navigation.py
@@ -1,12 +1,8 @@
 import dash_core_components as dcc
 import dash_html_components as html
-import pandas as pd
-
-from db import session
-from models import MatrixResult, Model, Combination
 
 
-def replicate_links(matrix):
+def replicate_links_from_matrix(matrix):
 
     link_text = lambda x: f"Barcode {x.barcode} ({x.project.name}) {'*' if x.HSA_excess > 0 else ''}"
 
@@ -25,53 +21,5 @@ def replicate_links(matrix):
     )
 
 
-def links_to_other_models(matrix):
 
-    other_model_matrices_query = session.query(MatrixResult.barcode, MatrixResult.cmatrix, MatrixResult.model_id, Model.name, Model.tissue)\
-        .filter(MatrixResult.model_id == Model.id)\
-        .filter(MatrixResult.model_id != matrix.model_id)\
-        .filter_by(drugset_id=matrix.drugset_id, cmatrix=matrix.cmatrix)
-
-    df_matrices = pd.read_sql(other_model_matrices_query.statement,
-                              con=session.bind)\
-        .sort_values('barcode')\
-        .drop_duplicates(subset=['model_id'])\
-        .sort_values('name')
-
-    return html.Div(
-        className='mb-4',
-        children=[
-            html.H5("Other models", className='mb-1'),
-            html.Span("(for the same combination)"),
-            dcc.Dropdown(options=[
-                {'label': f"{m.name} ({m.tissue if len(m.tissue) < 10 else m.tissue[:8] + '...'})",
-                 'value': f"{m.barcode}__{m.cmatrix}"}
-                for m in df_matrices.itertuples()
-            ], id='dropdown-models')
-
-        ])
-
-
-def links_to_other_combos(matrix):
-
-    other_combos = session.query(MatrixResult)\
-        .filter(MatrixResult.model_id == matrix.model_id)\
-        .order_by(MatrixResult.barcode.desc())\
-        .all()
-
-    dropdown_items = {f"{c.combination.lib1.drug_name} + {c.combination.lib2.drug_name}": f"{c.barcode}__{c.cmatrix}"
-                      for c in other_combos if c not in matrix.all_replicates}
-
-    return html.Div(
-        className='mb-4',
-        children=[
-            html.H5("Other Combinations", className='mb-1'),
-            html.Span("(for the same cell line)"),
-            dcc.Dropdown(options=[
-                {'label': k,
-                 'value': v}
-                for k, v in dropdown_items.items()
-            ], id='dropdown-combos')
-
-        ])
 

--- a/components/navigation/dropdowns.py
+++ b/components/navigation/dropdowns.py
@@ -1,0 +1,103 @@
+import dash
+import dash_html_components as html
+import dash_core_components as dcc
+import pandas as pd
+
+from app import app
+from db import session
+from models import MatrixResult, Model
+
+
+def generate_model_dropdown(model_list: pd.DataFrame,
+                            title="Other models",
+                            subtitle="(for the same combination)",
+                            max_tissue_width=10):
+    return html.Div(
+        className='mb-4',
+        children=[
+            dcc.Location('models-dropdown-url'),
+            html.H5(title, className='mb-1'),
+            html.Span(subtitle),
+            dcc.Dropdown(options=[
+                {'label': f"{m.name} ({m.tissue if len(m.tissue) < max_tissue_width else m.tissue[:max_tissue_width - 2] + '...'})",
+                 'value': f"{m.barcode}__{m.cmatrix}"}
+                for m in model_list.itertuples()
+            ], id='dropdown-models', className='mt-2')
+
+        ])
+
+
+def generate_combos_dropdown(combos: dict):
+    return html.Div(
+        className='mb-4',
+        children=[
+            dcc.Location('combos-dropdown-url'),
+            html.H5("Other Combinations", className='mb-1'),
+            html.Span("(for the same cell line)"),
+            dcc.Dropdown(options=[
+                {'label': k,
+                 'value': v}
+                for k, v in combos.items()
+            ], id='dropdown-combos', className='mt-2')
+
+        ])
+
+
+def model_links_from_matrix(matrix):
+
+    other_model_matrices_query = session.query(MatrixResult.barcode, MatrixResult.cmatrix, MatrixResult.model_id, Model.name, Model.tissue)\
+        .filter(MatrixResult.model_id == Model.id)\
+        .filter(MatrixResult.model_id != matrix.model_id)\
+        .filter_by(drugset_id=matrix.drugset_id, cmatrix=matrix.cmatrix)
+
+    unique_models = get_unique_models_from_matrices_query(other_model_matrices_query)
+    return generate_model_dropdown(unique_models)
+
+
+def model_links_from_combo(combination):
+    model_matrices_query = combination.matrices.join(Model)\
+        .with_entities(MatrixResult.barcode, MatrixResult.cmatrix,
+                       MatrixResult.model_id, Model.name, Model.tissue)
+    unique_models = get_unique_models_from_matrices_query(model_matrices_query)
+    return generate_model_dropdown(unique_models, title="Select cell line",
+                                   subtitle='(Navigates to most recent replicate)',
+                                   max_tissue_width=50)
+
+
+def get_unique_models_from_matrices_query(matrices_query):
+
+    return pd.read_sql(matrices_query.statement,
+                              con=session.bind)\
+        .sort_values('barcode', ascending=False)\
+        .drop_duplicates(subset=['model_id'])\
+        .sort_values('name')
+
+
+def combo_links_from_matrix(matrix):
+
+    other_combos = session.query(MatrixResult)\
+        .filter(MatrixResult.model_id == matrix.model_id)\
+        .order_by(MatrixResult.barcode.desc())\
+        .all()
+
+    dropdown_items = {f"{c.combination.lib1.drug_name} + {c.combination.lib2.drug_name}": f"{c.barcode}__{c.cmatrix}"
+                      for c in other_combos if c not in matrix.all_replicates}
+
+    return generate_combos_dropdown(dropdown_items)
+
+
+def url_from_dropdown_value(value):
+    barcode, cmatrix = value.split('__')
+    return f"/matrix/{barcode}/{cmatrix}"
+
+
+@app.callback(dash.dependencies.Output('models-dropdown-url', 'pathname'),
+              [dash.dependencies.Input('dropdown-models', 'value')])
+def dropdown_handler(dropdown_models_value):
+    return url_from_dropdown_value(dropdown_models_value)
+
+
+@app.callback(dash.dependencies.Output('combos-dropdown-url', 'pathname'),
+              [dash.dependencies.Input('dropdown-combos', 'value')])
+def dropdown_handler(dropdown_combos_value):
+    return url_from_dropdown_value(dropdown_combos_value)

--- a/models.py
+++ b/models.py
@@ -80,6 +80,16 @@ class Combination(ToDictMixin, Base):
         ))
 
     @property
+    def models(self):
+        return sa.orm.object_session(self).query(Model) \
+            .join(MatrixResult, Combination)\
+            .filter(
+                Combination.project_id == self.project_id,
+                Combination.lib1_id == self.lib1_id,
+                Combination.lib2_id == self.lib2_id)\
+            .all()
+
+    @property
     def replicates(self):
         return self.replicates_query.all()
 


### PR DESCRIPTION
Resolves #46 by adding a model selection dropdown to the combination page

I've refactored the dropdowns to a reusable component that takes a list of models and spits out a dropdown menu with working navigation.