### PR TITLE
Feature/style matrix page metrics

### DIFF
--- a/assets/matrixexplorer.css
+++ b/assets/matrixexplorer.css
@@ -1,0 +1,3 @@
+.badge{
+    font-size: 100%!important;
+}

--- a/assets/matrixexplorer.css
+++ b/assets/matrixexplorer.css
@@ -1,3 +1,10 @@
 .badge{
     font-size: 100%!important;
 }
+
+.matrix-metric .card-body {
+    padding-bottom: 0 !important;
+}
+.matrix-metric .card-body p{
+    padding-bottom: 1.25em;
+}

--- a/components/matrix_synergy.py
+++ b/components/matrix_synergy.py
@@ -105,7 +105,7 @@ def update_combo_heatmap(combo_heatmap_zvalue, combo_json, drug_names):
                 reversescale=False
             )
         ],
-        'layout': go.Layout(title=combo_heatmap_zvalue,
+        'layout': go.Layout(title=well_metrics[combo_heatmap_zvalue]['label'],
                             xaxis={'type': 'category',
                                    'title': drug1 + " µM"
                                    },

--- a/components/synergy_info/syn_info.py
+++ b/components/synergy_info/syn_info.py
@@ -1,93 +1,113 @@
 import numpy as np
 import dash_html_components as html
+import dash_core_components as dcc
+from textwrap import dedent
 
 
 def infoblock_matrix(matrix_result):
-    return html.Div([
-        html.Div([
-            html.H5(["Maximum inhibitory effect"]),
-            html.Table([
-                html.Tbody([
-                    html.Tr([
-                        html.Td([html.Strong("Combination")]),
-                        html.Td(f"{round(matrix_result.combo_max_effect * 100, 1)}% cell kill")
-                    ], className="colspan-2"),
-                    html.Tr([
-                        html.Td([html.Strong("lib1 max effect")]),
-                        html.Td(f"{round(matrix_result.lib1_max_effect * 100, 1)}% cell kill")
-                    ]),
-                    html.Tr([
-                        html.Td([html.Strong("lib2 max effect")]),
-                        html.Td(f"{round(matrix_result.lib2_max_effect * 100, 1)}% cell kill")
-                    ])
-                ])
-                # html.Strong("lib1_delta_max_effect"), round(matrix_result.lib1_delta_max_effect, 3), html.Br(),
-                #  html.Strong("lib2_delta_max_effect"), round(matrix_result.lib2_delta_max_effect, 3), html.Br()
-            ], className="table-borderless")
-        ], className="pb-4"),
-        html.Div([
-            html.H5(["Highest single agent effect (HSA)"]),
-            html.Table([
-                html.Tr([
-                    html.Td([html.Strong("Matrix average excess ")]),
-                    html.Td([html.Span(round(matrix_result.HSA_excess, 3), className="text-left")]),
-                ]),
-                html.Tr([
-                    html.Td([html.Strong(f"Average in {matrix_result.HSA_excess_well_count} wells with excess > 0")]),
-                    html.Td([html.Span(round(matrix_result.HSA_excess_syn, 3))])
-                ]) if matrix_result.HSA_excess_syn else ''
-            ])
-        ], className="pb-4"),
-        html.Div([
-            html.H5(["Bliss additivity"]),
-            html.Table([
-                html.Tr([
-                    html.Td([html.Strong("Matrix average excess ")]),
-                    html.Td([html.Span(round(matrix_result.Bliss_excess, 3))])
-                ]),
-                html.Tr([
-                    html.Td([html.Span(
-                        html.Strong(f"Average in {matrix_result.Bliss_excess_well_count} wells with excess > 0"))]),
-                    html.Td([html.Span(round(matrix_result.Bliss_excess_syn, 3))])
-                ]) if matrix_result.Bliss_excess_syn else ''
-            ])
-        ], className="pl-0, pb-2"),
 
-        html.Hr(),
-        html.Div([
-            html.H6("Best scoring windows in matrix"),
-            html.Table([
-                html.Tr([
-                    html.Td([
-                        html.Strong("Window size "), matrix_result.window_size, html.Br(),
-                        html.Strong("HSA excess "), round(matrix_result.HSA_excess_window, 3), html.Br(),
-                        html.Strong("HSA dose lib1 "), matrix_result.HSA_excess_window_dose_lib1,
-                        html.Br(),
-                        html.Strong("HSA dose lib2 "), matrix_result.HSA_excess_window_dose_lib2,
-                        html.Br(),
-                        html.Strong("HSA with excess > 0  "), round(matrix_result.HSA_excess_window_syn, 3), html.Br(),
-                        html.Strong("dose lib1 "), matrix_result.HSA_excess_window_syn_dose_lib1,
-                        html.Br(),
-                        html.Strong("dose lib2 "), matrix_result.HSA_excess_window_syn_dose_lib2,
-                        html.Br(),
-                        html.Strong("Bliss excess  "), round(matrix_result.Bliss_excess_window, 3), html.Br(),
-                        html.Strong("dose lib1 "), matrix_result.Bliss_excess_window_dose_lib1,
-                        html.Br(),
-                        html.Strong("dose lib2 "), matrix_result.Bliss_excess_window_dose_lib2,
-                        html.Br(),
-                        html.Strong("Bliss with excess > 0"), round(matrix_result.Bliss_excess_window_syn, 3),
-                        html.Br(),
-                        html.Strong("dose lib1 "),
-                        matrix_result.Bliss_excess_window_syn_dose_lib1, html.Br(),
-                        html.Strong("dose lib2 "),
-                        matrix_result.Bliss_excess_window_syn_dose_lib2, html.Br()
-                    ], className="pl-0")
+    return dcc.Markdown(dedent(
+        """
+        ## Matrix Summary Metrics  
+          
+        ### Bliss Excess  
+        **Average:** 0.184  
+        **Maximum:** 0.455 (10µM Drug1, 0.1µM Drug2)  
+        **Average for synergistic wells:** 0.329   
+        
+        ### HSA  
+        **Average:** 0.184  
+        **Maximum:** 0.455 (10µM Drug1, 0.1µM Drug2)  
+        **Average for synergistic wells:** 0.329  
+          
+        ### Loewe  
+        """))
 
-                ])
-            ])
-        ])
-
-    ])
+    # return html.Div([
+    #     html.Div([
+    #         html.H5(["Maximum inhibitory effect"]),
+    #         html.Table([
+    #             html.Tbody([
+    #                 html.Tr([
+    #                     html.Td([html.Strong("Combination")]),
+    #                     html.Td(f"{round(matrix_result.combo_max_effect * 100, 1)}% cell kill")
+    #                 ], className="colspan-2"),
+    #                 html.Tr([
+    #                     html.Td([html.Strong("lib1 max effect")]),
+    #                     html.Td(f"{round(matrix_result.lib1_max_effect * 100, 1)}% cell kill")
+    #                 ]),
+    #                 html.Tr([
+    #                     html.Td([html.Strong("lib2 max effect")]),
+    #                     html.Td(f"{round(matrix_result.lib2_max_effect * 100, 1)}% cell kill")
+    #                 ])
+    #             ])
+    #             # html.Strong("lib1_delta_max_effect"), round(matrix_result.lib1_delta_max_effect, 3), html.Br(),
+    #             #  html.Strong("lib2_delta_max_effect"), round(matrix_result.lib2_delta_max_effect, 3), html.Br()
+    #         ], className="table-borderless")
+    #     ], className="pb-4"),
+    #     html.Div([
+    #         html.H5(["Highest single agent effect (HSA)"]),
+    #         html.Table([
+    #             html.Tr([
+    #                 html.Td([html.Strong("Matrix average excess ")]),
+    #                 html.Td([html.Span(round(matrix_result.HSA_excess, 3), className="text-left")]),
+    #             ]),
+    #             html.Tr([
+    #                 html.Td([html.Strong(f"Average in {matrix_result.HSA_excess_well_count} wells with excess > 0")]),
+    #                 html.Td([html.Span(round(matrix_result.HSA_excess_syn, 3))])
+    #             ]) if matrix_result.HSA_excess_syn else ''
+    #         ])
+    #     ], className="pb-4"),
+    #     html.Div([
+    #         html.H5(["Bliss additivity"]),
+    #         html.Table([
+    #             html.Tr([
+    #                 html.Td([html.Strong("Matrix average excess ")]),
+    #                 html.Td([html.Span(round(matrix_result.Bliss_excess, 3))])
+    #             ]),
+    #             html.Tr([
+    #                 html.Td([html.Span(
+    #                     html.Strong(f"Average in {matrix_result.Bliss_excess_well_count} wells with excess > 0"))]),
+    #                 html.Td([html.Span(round(matrix_result.Bliss_excess_syn, 3))])
+    #             ]) if matrix_result.Bliss_excess_syn else ''
+    #         ])
+    #     ], className="pl-0, pb-2"),
+    #
+    #     html.Hr(),
+    #     html.Div([
+    #         html.H6("Best scoring windows in matrix"),
+    #         html.Table([
+    #             html.Tr([
+    #                 html.Td([
+    #                     html.Strong("Window size "), matrix_result.window_size, html.Br(),
+    #                     html.Strong("HSA excess "), round(matrix_result.HSA_excess_window, 3), html.Br(),
+    #                     html.Strong("HSA dose lib1 "), matrix_result.HSA_excess_window_dose_lib1,
+    #                     html.Br(),
+    #                     html.Strong("HSA dose lib2 "), matrix_result.HSA_excess_window_dose_lib2,
+    #                     html.Br(),
+    #                     html.Strong("HSA with excess > 0  "), round(matrix_result.HSA_excess_window_syn, 3), html.Br(),
+    #                     html.Strong("dose lib1 "), matrix_result.HSA_excess_window_syn_dose_lib1,
+    #                     html.Br(),
+    #                     html.Strong("dose lib2 "), matrix_result.HSA_excess_window_syn_dose_lib2,
+    #                     html.Br(),
+    #                     html.Strong("Bliss excess  "), round(matrix_result.Bliss_excess_window, 3), html.Br(),
+    #                     html.Strong("dose lib1 "), matrix_result.Bliss_excess_window_dose_lib1,
+    #                     html.Br(),
+    #                     html.Strong("dose lib2 "), matrix_result.Bliss_excess_window_dose_lib2,
+    #                     html.Br(),
+    #                     html.Strong("Bliss with excess > 0"), round(matrix_result.Bliss_excess_window_syn, 3),
+    #                     html.Br(),
+    #                     html.Strong("dose lib1 "),
+    #                     matrix_result.Bliss_excess_window_syn_dose_lib1, html.Br(),
+    #                     html.Strong("dose lib2 "),
+    #                     matrix_result.Bliss_excess_window_syn_dose_lib2, html.Br()
+    #                 ], className="pl-0")
+    #
+    #             ])
+    #         ])
+    #     ])
+    #
+    # ])
 
 
     #

--- a/components/synergy_info/syn_info.py
+++ b/components/synergy_info/syn_info.py
@@ -37,13 +37,64 @@ def infoblock_matrix(matrix_result):
         html.Div(className='card mb-3', children=[
             html.Div(className='card-body', children=[
                 html.H4(className='card-title', children=[
+                    "Maximum Effect"
+                ]),
+                html.P(className='card-text', children=[
+                    "Color indicates percentile bracket for this combination",
+                    html.Br(),
+                    html.Strong("Top 33% ", className='badge badge-success'),
+                    html.Span(" "),
+                    html.Strong("Middle 33% ", className='badge badge-danger'),
+                    html.Span(" "),
+                    html.Strong("Bottom 33% ", className='badge badge-primary'),
+                    html.Span(" "),
+                ])
+            ]),
+            html.Ul(className='list-group list-group-flush', children=[
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Span("Combo max effect"),
+                        get_pill(matrix_result, 'combo_max_effect')
+                    ]),
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Span(f"{matrix_result.combination.lib1.drug_name} max effect"),
+                        get_pill(matrix_result, 'lib1_max_effect')
+                    ]),
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Span(
+                            f"∆ max effect {matrix_result.combination.lib1.drug_name}"),
+                        get_pill(matrix_result, 'lib1_delta_max_effect')
+                    ]),
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Span(f"{matrix_result.combination.lib2.drug_name} max effect"),
+                        get_pill(matrix_result, 'lib2_max_effect')
+                    ]),
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Span(
+                            f"∆ max effect {matrix_result.combination.lib2.drug_name}"),
+                        get_pill(matrix_result, 'lib2_delta_max_effect')
+                    ]),
+            ])
+        ]),
+        html.Div(className='card mb-3', children=[
+            html.Div(className='card-body', children=[
+                html.H4(className='card-title', children=[
                     "Bliss Excess"
                 ]),
                 html.P(className='card-text', children=[
-                    "Color indicates percentile bracket for this combination", html.Br(),
-                    html.Strong("Top 33% ", className='badge badge-success'), html.Span(" "),
-                    html.Strong("Middle 33% ", className='badge badge-danger'), html.Span(" "),
-                    html.Strong("Bottom 33% ", className='badge badge-primary'), html.Span(" "),
+                    "Average Bliss in the matrix or 3x3 window.", html.Br(),
+                    # html.Strong("Top 33% ", className='badge badge-success'), html.Span(" "),
+                    # html.Strong("Middle 33% ", className='badge badge-danger'), html.Span(" "),
+                    # html.Strong("Bottom 33% ", className='badge badge-primary'), html.Span(" "),
                 ])
             ]),
             html.Ul(className='list-group list-group-flush', children=[
@@ -71,7 +122,14 @@ def infoblock_matrix(matrix_result):
                     "HSA Excess"
                 ]),
                 html.P(className='card-text', children=[
-                    "Average excess over the highest single agent in the matrix or 3x3 window."
+                    "Average excess over the highest single agent in the matrix or 3x3 window.",
+                    html.Br(),
+                    # html.Strong("Top 33% ", className='badge badge-success'),
+                    # html.Span(" "),
+                    # html.Strong("Middle 33% ", className='badge badge-danger'),
+                    # html.Span(" "),
+                    # html.Strong("Bottom 33% ", className='badge badge-primary'),
+                    # html.Span(" "),
                 ])
             ]),
             html.Ul(className='list-group list-group-flush', children=[

--- a/components/synergy_info/syn_info.py
+++ b/components/synergy_info/syn_info.py
@@ -6,23 +6,72 @@ from textwrap import dedent
 
 def infoblock_matrix(matrix_result):
 
-    return dcc.Markdown(dedent(
-        """
-        ## Matrix Summary Metrics  
-          
-        ### Bliss Excess  
-        **Average:** 0.184  
-        **Maximum:** 0.455 (10µM Drug1, 0.1µM Drug2)  
-        **Average for synergistic wells:** 0.329   
-        
-        ### HSA  
-        **Average:** 0.184  
-        **Maximum:** 0.455 (10µM Drug1, 0.1µM Drug2)  
-        **Average for synergistic wells:** 0.329  
-          
-        ### Loewe  
-        """))
-
+    return html.Div([
+        html.Div(className='card mb-3', children=[
+            html.Div(className='card-body', children=[
+                html.H5(className='card-title', children=[
+                    "Bliss Excess"
+                ]),
+                html.P(className='card-text', children=[
+                    "Average Bliss Excess scores over the matrix or 3x3 window."
+                ])
+            ]),
+            html.Ul(className='list-group list-group-flush', children=[
+                html.Li(className='list-group-item d-flex justify-content-between align-items-center', children=[
+                    html.Strong("Matrix average"),
+                    html.Span("0.291")
+                ]),
+                html.Li(className='list-group-item d-flex justify-content-between align-items-center', children=[
+                    html.Strong("Matrix average synergistic wells"),
+                    html.Span("0.382")
+                ]),
+                html.Li(className='list-group-item d-flex justify-content-between align-items-center', children=[
+                    html.Strong("Highest window"),
+                    html.Span("0.456")
+                ]),
+                html.Li(className='list-group-item d-flex justify-content-between align-items-center', children=[
+                    html.Strong("Highest window synergistic wells"),
+                    html.Span("0.456")
+                ])
+            ])
+        ]),
+        html.Div(className='card mb-3', children=[
+            html.Div(className='card-body', children=[
+                html.H4(className='card-title', children=[
+                    "HSA Excess"
+                ]),
+                html.P(className='card-text', children=[
+                    "Average excess over the highest single agent in the matrix or 3x3 window."
+                ])
+            ]),
+            html.Ul(className='list-group list-group-flush', children=[
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Strong("Average"),
+                        html.Span("0.291")
+                    ]),
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Strong("Average synergistic wells"),
+                        html.Span("0.382")
+                    ]),
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Strong("Highest window"),
+                        html.Span("0.456")
+                    ]),
+                html.Li(
+                    className='list-group-item d-flex justify-content-between align-items-center',
+                    children=[
+                        html.Strong("Highest window synergistic wells"),
+                        html.Span("0.456")
+                    ])
+            ])
+        ])
+    ])
     # return html.Div([
     #     html.Div([
     #         html.H5(["Maximum inhibitory effect"]),

--- a/components/synergy_info/syn_info.py
+++ b/components/synergy_info/syn_info.py
@@ -34,13 +34,13 @@ def get_pill(matrix, metric):
 def infoblock_matrix(matrix_result):
 
     return html.Div([
-        html.Div(className='card mb-3', children=[
+        html.Div(className='card mb-3 matrix-metric', children=[
             html.Div(className='card-body', children=[
                 html.H4(className='card-title', children=[
                     "Maximum Effect"
                 ]),
                 html.P(className='card-text', children=[
-                    "Color indicates percentile bracket for this combination",
+                    "Color indicates combination percentile bracket",
                     html.Br(),
                     html.Strong("Top 33% ", className='badge badge-success'),
                     html.Span(" "),
@@ -54,47 +54,41 @@ def infoblock_matrix(matrix_result):
                 html.Li(
                     className='list-group-item d-flex justify-content-between align-items-center',
                     children=[
-                        html.Span("Combo max effect"),
+                        html.Strong("Combination"),
                         get_pill(matrix_result, 'combo_max_effect')
                     ]),
                 html.Li(
                     className='list-group-item d-flex justify-content-between align-items-center',
                     children=[
-                        html.Span(f"{matrix_result.combination.lib1.drug_name} max effect"),
+                        html.Span(f"{matrix_result.combination.lib1.drug_name}"),
                         get_pill(matrix_result, 'lib1_max_effect')
                     ]),
                 html.Li(
                     className='list-group-item d-flex justify-content-between align-items-center',
                     children=[
                         html.Span(
-                            f"∆ max effect {matrix_result.combination.lib1.drug_name}"),
+                            f"∆ {matrix_result.combination.lib1.drug_name}"),
                         get_pill(matrix_result, 'lib1_delta_max_effect')
                     ]),
                 html.Li(
                     className='list-group-item d-flex justify-content-between align-items-center',
                     children=[
-                        html.Span(f"{matrix_result.combination.lib2.drug_name} max effect"),
+                        html.Span(f"{matrix_result.combination.lib2.drug_name}"),
                         get_pill(matrix_result, 'lib2_max_effect')
                     ]),
                 html.Li(
                     className='list-group-item d-flex justify-content-between align-items-center',
                     children=[
                         html.Span(
-                            f"∆ max effect {matrix_result.combination.lib2.drug_name}"),
+                            f"∆ {matrix_result.combination.lib2.drug_name}"),
                         get_pill(matrix_result, 'lib2_delta_max_effect')
                     ]),
             ])
         ]),
-        html.Div(className='card mb-3', children=[
+        html.Div(className='card mb-3 matrix-metric', children=[
             html.Div(className='card-body', children=[
                 html.H4(className='card-title', children=[
                     "Bliss Excess"
-                ]),
-                html.P(className='card-text', children=[
-                    "Average Bliss in the matrix or 3x3 window.", html.Br(),
-                    # html.Strong("Top 33% ", className='badge badge-success'), html.Span(" "),
-                    # html.Strong("Middle 33% ", className='badge badge-danger'), html.Span(" "),
-                    # html.Strong("Bottom 33% ", className='badge badge-primary'), html.Span(" "),
                 ])
             ]),
             html.Ul(className='list-group list-group-flush', children=[
@@ -116,21 +110,11 @@ def infoblock_matrix(matrix_result):
                 ])
             ])
         ]),
-        html.Div(className='card mb-3', children=[
+        html.Div(className='card mb-3 matrix-metric', children=[
             html.Div(className='card-body', children=[
                 html.H4(className='card-title', children=[
                     "HSA Excess"
                 ]),
-                html.P(className='card-text', children=[
-                    "Average excess over the highest single agent in the matrix or 3x3 window.",
-                    html.Br(),
-                    # html.Strong("Top 33% ", className='badge badge-success'),
-                    # html.Span(" "),
-                    # html.Strong("Middle 33% ", className='badge badge-danger'),
-                    # html.Span(" "),
-                    # html.Strong("Bottom 33% ", className='badge badge-primary'),
-                    # html.Span(" "),
-                ])
             ]),
             html.Ul(className='list-group list-group-flush', children=[
                 html.Li(

--- a/components/synergy_info/syn_info.py
+++ b/components/synergy_info/syn_info.py
@@ -1,9 +1,8 @@
 from functools import lru_cache
 
 import dash_html_components as html
-import pandas as pd
 
-from db import session
+from utils import get_combination_matrices_summary
 
 
 def get_badge_classname(value, context, metric):
@@ -15,13 +14,11 @@ def get_badge_classname(value, context, metric):
         return 'badge-success'
 
 
-# This is only cached for an individual request as the 'matrix'-object is different for each request.
-# A more elegant solution would cache the context for any combination
 @lru_cache()
 def get_context(matrix):
-    return pd.read_sql(matrix.combination.matrices.statement,
-                          session.get_bind()) \
-        .describe(percentiles=[0.33, 0.67])
+    return get_combination_matrices_summary(
+        matrix.project_id, matrix.lib1_id, matrix.lib2_id,
+        percentiles=(0.33, 0.67))
 
 
 def get_pill(matrix, metric):
@@ -144,92 +141,3 @@ def infoblock_matrix(matrix_result):
             ])
         ])
     ])
-    # return html.Div([
-    #     html.Div([
-    #         html.H5(["Maximum inhibitory effect"]),
-    #         html.Table([
-    #             html.Tbody([
-    #                 html.Tr([
-    #                     html.Td([html.Strong("Combination")]),
-    #                     html.Td(f"{round(matrix_result.combo_max_effect * 100, 1)}% cell kill")
-    #                 ], className="colspan-2"),
-    #                 html.Tr([
-    #                     html.Td([html.Strong("lib1 max effect")]),
-    #                     html.Td(f"{round(matrix_result.lib1_max_effect * 100, 1)}% cell kill")
-    #                 ]),
-    #                 html.Tr([
-    #                     html.Td([html.Strong("lib2 max effect")]),
-    #                     html.Td(f"{round(matrix_result.lib2_max_effect * 100, 1)}% cell kill")
-    #                 ])
-    #             ])
-    #             # html.Strong("lib1_delta_max_effect"), round(matrix_result.lib1_delta_max_effect, 3), html.Br(),
-    #             #  html.Strong("lib2_delta_max_effect"), round(matrix_result.lib2_delta_max_effect, 3), html.Br()
-    #         ], className="table-borderless")
-    #     ], className="pb-4"),
-    #     html.Div([
-    #         html.H5(["Highest single agent effect (HSA)"]),
-    #         html.Table([
-    #             html.Tr([
-    #                 html.Td([html.Strong("Matrix average excess ")]),
-    #                 html.Td([html.Span(round(matrix_result.HSA_excess, 3), className="text-left")]),
-    #             ]),
-    #             html.Tr([
-    #                 html.Td([html.Strong(f"Average in {matrix_result.HSA_excess_well_count} wells with excess > 0")]),
-    #                 html.Td([html.Span(round(matrix_result.HSA_excess_syn, 3))])
-    #             ]) if matrix_result.HSA_excess_syn else ''
-    #         ])
-    #     ], className="pb-4"),
-    #     html.Div([
-    #         html.H5(["Bliss additivity"]),
-    #         html.Table([
-    #             html.Tr([
-    #                 html.Td([html.Strong("Matrix average excess ")]),
-    #                 html.Td([html.Span(round(matrix_result.Bliss_excess, 3))])
-    #             ]),
-    #             html.Tr([
-    #                 html.Td([html.Span(
-    #                     html.Strong(f"Average in {matrix_result.Bliss_excess_well_count} wells with excess > 0"))]),
-    #                 html.Td([html.Span(round(matrix_result.Bliss_excess_syn, 3))])
-    #             ]) if matrix_result.Bliss_excess_syn else ''
-    #         ])
-    #     ], className="pl-0, pb-2"),
-    #
-    #     html.Hr(),
-    #     html.Div([
-    #         html.H6("Best scoring windows in matrix"),
-    #         html.Table([
-    #             html.Tr([
-    #                 html.Td([
-    #                     html.Strong("Window size "), matrix_result.window_size, html.Br(),
-    #                     html.Strong("HSA excess "), round(matrix_result.HSA_excess_window, 3), html.Br(),
-    #                     html.Strong("HSA dose lib1 "), matrix_result.HSA_excess_window_dose_lib1,
-    #                     html.Br(),
-    #                     html.Strong("HSA dose lib2 "), matrix_result.HSA_excess_window_dose_lib2,
-    #                     html.Br(),
-    #                     html.Strong("HSA with excess > 0  "), round(matrix_result.HSA_excess_window_syn, 3), html.Br(),
-    #                     html.Strong("dose lib1 "), matrix_result.HSA_excess_window_syn_dose_lib1,
-    #                     html.Br(),
-    #                     html.Strong("dose lib2 "), matrix_result.HSA_excess_window_syn_dose_lib2,
-    #                     html.Br(),
-    #                     html.Strong("Bliss excess  "), round(matrix_result.Bliss_excess_window, 3), html.Br(),
-    #                     html.Strong("dose lib1 "), matrix_result.Bliss_excess_window_dose_lib1,
-    #                     html.Br(),
-    #                     html.Strong("dose lib2 "), matrix_result.Bliss_excess_window_dose_lib2,
-    #                     html.Br(),
-    #                     html.Strong("Bliss with excess > 0"), round(matrix_result.Bliss_excess_window_syn, 3),
-    #                     html.Br(),
-    #                     html.Strong("dose lib1 "),
-    #                     matrix_result.Bliss_excess_window_syn_dose_lib1, html.Br(),
-    #                     html.Strong("dose lib2 "),
-    #                     matrix_result.Bliss_excess_window_syn_dose_lib2, html.Br()
-    #                 ], className="pl-0")
-    #
-    #             ])
-    #         ])
-    #     ])
-    #
-    # ])
-
-
-    #
-    # ], className="flex-grow-1")

--- a/utils.py
+++ b/utils.py
@@ -217,6 +217,7 @@ def get_project_from_url(url):
         return html.Div("Project not found")
     return project
 
+
 @lru_cache()
 def get_combination_from_url(url):
     if not url.startswith("/project"):
@@ -273,3 +274,14 @@ def get_combination_results_with_sa(combination):
         .drop(columns=['dosed_tag_lib1', 'dosed_tag_lib2'])
 
     return combo_matrices
+
+
+@lru_cache()
+def get_combination_matrices_summary(project_id, lib1_id, lib2_id, percentiles):
+    percentiles = list(percentiles)
+    query = session.query(models.MatrixResult) \
+        .filter(models.MatrixResult.project_id == project_id) \
+        .filter(models.MatrixResult.lib1_id == lib1_id) \
+        .filter(models.MatrixResult.lib2_id == lib2_id)
+    return pd.read_sql(query.statement, session.get_bind())\
+        .describe(percentiles=percentiles)

--- a/utils.py
+++ b/utils.py
@@ -150,7 +150,6 @@ def get_metric_min_max(metric):
 
 def get_metric_axis_range(metric):
     min_val, max_val = get_metric_min_max(metric)
-    print(min_val, max_val)
     try:
         return math.floor(min_val * 10) / 10, math.ceil(max_val * 10) / 10
     except OverflowError:


### PR DESCRIPTION
Tidy up the metrics display on the matrix page. To best understand the changes, it is probably easier to checkout the feature branch and spin it up yourself.

As a good example, have a look at /matrix/28875/2